### PR TITLE
Use the Authorization request header field to send tokens instead of the URI query string.

### DIFF
--- a/lib/request-jwt.js
+++ b/lib/request-jwt.js
@@ -32,9 +32,8 @@ exports.requestWithJWT = function (request) {
 
 				if (err) return callback(err);
 
-				// TODO: for now the token is only passed using the query string
-				options.qs = options.qs || {};
-				options.qs.access_token = token;
+				options.headers = options.headers || {};
+				options.headers.authorization = 'Bearer ' + token;
 				return request(uri, options, callback);
 
 			});


### PR DESCRIPTION
Per http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-14#section-2.1
this is the recommended approach which must be supported by all servers.
