### PR TITLE
fix auth request Content-Type header

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -27,8 +27,7 @@ exports.authenticate = function (options, callback) {
 			form: {
 				grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
 				assertion: jwt
-			},
-			json: true
+			}
 		}, function (err, res, body) {
 			
 			if (err) {
@@ -45,6 +44,13 @@ exports.authenticate = function (options, callback) {
 				err.statusCode = res.statusCode;
 				err.body = body;
 				return callback(err);
+			}
+
+			try {
+				body = JSON.parse(body);
+			}
+			catch (e) {
+				return callback(new Error('failed to parse response body: ' + body));
 			}
 
 			return callback(null, body.access_token);


### PR DESCRIPTION
When json: true is specified, request adds Content-Type: application/json which results in a 400 response. This workaround removes json:true and manually parses the response body instead.
