### PR TITLE
Reset TokenRequest state after authentication failure

### DIFF
--- a/lib/token-cache.js
+++ b/lib/token-cache.js
@@ -72,9 +72,9 @@ function TokenRequest(authenticate, options) {
 
 			authenticate(options, function (err, token) {
 				if (err) {
-          self.status = 'expired';
-          return fireCallbacks(err, null);
-        }
+					self.status = 'expired';
+					return fireCallbacks(err, null);
+				}
 				self.issued = Date.now();
 				self.duration = options.expiration || 60 * 60 * 1000;
 				self.token = token;


### PR DESCRIPTION
to prevent subsequent get() calls from hanging
