### PR TITLE
changes claims.prn to claims.sub

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -98,7 +98,7 @@ exports.encodeJWT = function (options, callback) {
 		};
 
 	if (options.delegationEmail) {
-		claims.prn = options.delegationEmail;
+		claims.sub = options.delegationEmail;
 	}
 
 	var JWT_header = new Buffer(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString('base64'),


### PR DESCRIPTION
according to the Google documentation as of 04/24/2014:

Additional Claims:
sub - The email address of the user for which the application is requesting delegated access.

https://developers.google.com/accounts/docs/OAuth2ServiceAccount#additionalclaims

I manually tested this locally and both `claims.prn` and `claims.sub` worked successfully. Perhaps Google deprecated `claims.prn` and just has not removed it yet? 

I do not have an automated way to test this.
