### PR TITLE
fix error messages properly

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -36,6 +36,13 @@ exports.authenticate = function (options, callback) {
 				debug('response from OAuth server: HTTP %d -> %j', res.statusCode, body);
 			}
 
+			try {
+				body = JSON.parse(body);
+			}
+			catch (e) {
+				return callback(new Error('failed to parse response body: ' + body));
+			}
+
 			if (res.statusCode != 200) {
 				err = new Error(
 					'failed to obtain an authentication token, request failed with HTTP code ' +
@@ -44,13 +51,6 @@ exports.authenticate = function (options, callback) {
 				err.statusCode = res.statusCode;
 				err.body = body;
 				return callback(err);
-			}
-
-			try {
-				body = JSON.parse(body);
-			}
-			catch (e) {
-				return callback(new Error('failed to parse response body: ' + body));
 			}
 
 			return callback(null, body.access_token);


### PR DESCRIPTION
When an authentication token isn't obtained, the error message is:

```
{ [Error: failed to obtain an authentication token, request failed with HTTP code 400: undefined] statusCode: 400, body: '{\n  "error" : "invalid_grant"\n}' }
```

Because `body` is just string- not json, so `body.error` is `undefined`. So, I moved `JSON.parse(body)` part above creating Error instance. Now. the error message is:

```
{ [Error: failed to obtain an authentication token, request failed with HTTP code 400: invalid_grant] statusCode: 400, body: { error: 'invalid_grant' } }
```

